### PR TITLE
EntityクラスとしてAirportデータクラスを定義

### DIFF
--- a/app/src/main/java/com/example/flightsearch/data/Airport.kt
+++ b/app/src/main/java/com/example/flightsearch/data/Airport.kt
@@ -1,0 +1,17 @@
+package com.example.flightsearch.data
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "airport")
+data class Airport(
+    @PrimaryKey
+    val id: Int,
+    @ColumnInfo(name = "name")
+    val name: String,
+    @ColumnInfo(name = "iata_code")
+    val iataCode: String,
+    @ColumnInfo(name = "passengers")
+    val passengers: Int
+)


### PR DESCRIPTION
## 概要
フライトデータベースに対してクエリを行い、ユーザーの入力に応じて予測入力の候補を提示するために、
`flight_search.db`の`airport`テーブルのエンティティを定義。

## 変更内容
`data`パッケージ下に`Airport`クラスを追加。