### PR TITLE
AirportDaoインターフェイスを定義

### DIFF
--- a/.idea/deviceManager.xml
+++ b/.idea/deviceManager.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DeviceTable">
+    <option name="columnSorters">
+      <list>
+        <ColumnSorterState>
+          <option name="column" value="Name" />
+          <option name="order" value="ASCENDING" />
+        </ColumnSorterState>
+      </list>
+    </option>
+  </component>
+</project>

--- a/app/src/main/java/com/example/flightsearch/data/AirportDao.kt
+++ b/app/src/main/java/com/example/flightsearch/data/AirportDao.kt
@@ -1,0 +1,11 @@
+package com.example.flightsearch.data
+
+import androidx.room.Dao
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface AirportDao {
+    @Query("SELECT * FROM airport WHERE iata_code LIKE :query || '%' OR name LIKE :query || '%' ORDER BY passengers DESC")
+    suspend fun searchAirports(query: String): Flow<List<Airport>>
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-agp = "8.10.1"
-kotlin = "2.0.21"
+agp = "8.11.1"
+kotlin = "2.1.0"
 coreKtx = "1.16.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
@@ -8,7 +8,7 @@ espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.9.1"
 activityCompose = "1.10.1"
 composeBom = "2024.09.00"
-ksp= "1.9.0-1.0.13"
+ksp= "2.1.0-1.0.29"
 room = "2.7.2"
 
 [libraries]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jul 09 18:05:29 JST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## 概要
`AirportDao.kt`に`AirportDao`インターフェイスを定義し、`airport`テーブルのうち、空港名(`name`)またはIATAコード(`iata_code`)の値と比較するためのメソッドを定義

## 変更内容
`data`パッケージ下に`AirportDao`を定義。
`ksp`プラグインと`kotlin`プラグインの互換性エラーを解除するためにバージョンをそれぞれ変更