### PR TITLE
FlightSearchViewModelクラスを追加

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,6 +41,8 @@ android {
 }
 
 dependencies {
+    // ViewModel
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
     // Room
     implementation(libs.androidx.room.runtime)
     ksp(libs.androidx.room.compiler)

--- a/app/src/main/java/com/example/flightsearch/data/AirportDao.kt
+++ b/app/src/main/java/com/example/flightsearch/data/AirportDao.kt
@@ -7,5 +7,5 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface AirportDao {
     @Query("SELECT * FROM airport WHERE iata_code LIKE :query || '%' OR name LIKE :query || '%' ORDER BY passengers DESC")
-    suspend fun searchAirports(query: String): Flow<List<Airport>>
+    fun searchAirports(query: String): Flow<List<Airport>>
 }

--- a/app/src/main/java/com/example/flightsearch/ui/FlightSearchViewModel.kt
+++ b/app/src/main/java/com/example/flightsearch/ui/FlightSearchViewModel.kt
@@ -1,0 +1,38 @@
+package com.example.flightsearch.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.flightsearch.data.Airport
+import com.example.flightsearch.data.AirportDao
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.stateIn
+import kotlin.collections.emptyList
+
+class FlightSearchViewModel(private val airportDao: AirportDao) : ViewModel() {
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
+    @OptIn(kotlinx.coroutines.FlowPreview::class)
+    @kotlinx.coroutines.ExperimentalCoroutinesApi
+    val airportSuggestions: StateFlow<List<Airport>> = _searchQuery
+        .debounce(300L)
+        .distinctUntilChanged()
+        .flatMapLatest { query ->
+            if (query.isBlank()) {
+                MutableStateFlow(emptyList())
+            } else {
+                airportDao.searchAirports(query)
+            }
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = emptyList()
+        )
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,8 +10,10 @@ activityCompose = "1.10.1"
 composeBom = "2024.09.00"
 ksp= "2.1.0-1.0.29"
 room = "2.7.2"
+viewModel = "2.6.2"
 
 [libraries]
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "viewModel" }
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }


### PR DESCRIPTION
## 概要
UI要素(`MainActity`)からUI状態(ユーザの入力に応じて変化する検索文字列)を分離するため、DAOオブジェクト(`AirportDao`)を用いて、データベースからデータを`ViewModel`を介して、UI要素に伝えるためにViewModelクラスとして、`FlightSearchViewModel`クラスを定義

## 変更内容
`FlightSearchViewModel`クラスを追加

