### PR TITLE
FlightSearchApplicationクラスを追加

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
+        android:name=".FlightSearchApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/example/flightsearch/FlightSearchApplication.kt
+++ b/app/src/main/java/com/example/flightsearch/FlightSearchApplication.kt
@@ -1,0 +1,10 @@
+package com.example.flightsearch
+
+import android.app.Application
+import com.example.flightsearch.data.FlightSearchDatabase
+
+class FlightSearchApplication : Application() {
+    val database: FlightSearchDatabase by lazy {
+        FlightSearchDatabase.getDatabase(this)
+    }
+}

--- a/app/src/main/java/com/example/flightsearch/data/FlightSearchDatabase.kt
+++ b/app/src/main/java/com/example/flightsearch/data/FlightSearchDatabase.kt
@@ -6,18 +6,18 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 
 @Database(entities = [Airport::class], version = 1)
-abstract class flightSearchDatabase : RoomDatabase() {
+abstract class FlightSearchDatabase : RoomDatabase() {
     abstract fun airportDao(): AirportDao
 
-    companion object {
+    companion object Companion {
         @Volatile
-        private var Instance: flightSearchDatabase? = null
+        private var Instance: FlightSearchDatabase? = null
 
-        fun getDatabase(context: Context): flightSearchDatabase {
+        fun getDatabase(context: Context): FlightSearchDatabase {
             return Instance ?: synchronized(this) {
                 Room.databaseBuilder(
                     context,
-                    flightSearchDatabase::class.java,
+                    FlightSearchDatabase::class.java,
                     "flight_search_database"
                 )
                     .createFromAsset("database/flight_search.db")


### PR DESCRIPTION
## 概要
データベースインスタンスをアプリ全体で保持するために`Applcation()`を拡張した`FlightSearchApplication`クラスを定義。

## 変更内容
`com/example/flightSearch/`内に`FlightSearchApplication.kt`を追加
`FlightSearchApplication()`内で、`database`インスタンスを保持するために、`flighSearchtDatabase`から`FlightSearchDatabase`にファイル名を変更
`アプリクラスを使用できるように、`AndroidManifest`を変更