### PR TITLE
ViewModelProvider.Factoryを実装

### DIFF
--- a/app/src/main/java/com/example/flightsearch/ui/FlightSearchViewModel.kt
+++ b/app/src/main/java/com/example/flightsearch/ui/FlightSearchViewModel.kt
@@ -1,7 +1,12 @@
 package com.example.flightsearch.ui
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.example.flightsearch.FlightSearchApplication
 import com.example.flightsearch.data.Airport
 import com.example.flightsearch.data.AirportDao
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -35,4 +40,20 @@ class FlightSearchViewModel(private val airportDao: AirportDao) : ViewModel() {
             started = SharingStarted.WhileSubscribed(5000),
             initialValue = emptyList()
         )
+
+//  FlightSearchViewModelをインスタンス化するためのFactoryを定義
+//  AirportDaoがコンストラクタで必要なため、カスタムFactoryを定義
+    companion object {
+        val Factory: ViewModelProvider.Factory = viewModelFactory {
+            initializer {
+                // ApplicationContextを取得
+                val application = (this[APPLICATION_KEY] as FlightSearchApplication)
+                // Applicationクラス経由で、AirportDaoを取得
+                val airportDao = application.database.airportDao()
+                // AirportDaoを渡してFlightSearchViewModelをインスタンス化
+                FlightSearchViewModel(airportDao)
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
## 概要
`FlightSearchVIewModel`のコンストラクタに`AirportDao`を渡すために必要な`ViewModelProvider.Factory`を定義

## 変更内容
`FlightSearchViewModel.kt`の43~58行目の間に`ViewModelProvider.Factory`を追加。