### PR TITLE
MainActivityクラスでViewModelで定義したUI状態とロジックを利用

### DIFF
--- a/app/src/main/java/com/example/flightsearch/ui/FlightSearchViewModel.kt
+++ b/app/src/main/java/com/example/flightsearch/ui/FlightSearchViewModel.kt
@@ -41,6 +41,10 @@ class FlightSearchViewModel(private val airportDao: AirportDao) : ViewModel() {
             initialValue = emptyList()
         )
 
+    fun onSearchQueryChange(newQuery: String) {
+        _searchQuery.value = newQuery
+    }
+
 //  FlightSearchViewModelをインスタンス化するためのFactoryを定義
 //  AirportDaoがコンストラクタで必要なため、カスタムFactoryを定義
     companion object {


### PR DESCRIPTION
## 概要
`MainActivity.kt`で`FlightSearchViewModel`をインスタンス化し、UI状態とロジックを使用

## 変更内容
`MainActivity.kt`を変更
61行目：`FlightSearchApp()`のパラメータとして、`viewModel: FlightSearchViewModel = viewModel(factory = FlightViewModel.factory)を追加。
63行目：検索クエリ文字列状態を`collectAsState()`で管理。
64行目：データベースにクエリした結果を`collectAsState()`で管理。